### PR TITLE
Feat: Messages, System-Prompt, and responses api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ dependencies = [
  "futures",
  "log",
  "once_cell",
- "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -63,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.29.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31acf814d6b499e33ec894bb0fd7ddaf2665b44fbdd42b858d736449271fde0c"
+checksum = "d4fc47ec9e669d562e0755f59e1976d157546910e403f3c2da856d0a4d3cdc07"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -74,7 +73,7 @@ dependencies = [
  "derive_builder",
  "eventsource-stream",
  "futures",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "reqwest-eventsource",
  "secrecy",
@@ -108,12 +107,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -246,16 +239,6 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -418,21 +401,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,21 +432,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -652,31 +605,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-
-[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,7 +662,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -763,22 +690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,11 +708,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -958,16 +867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,23 +1019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,48 +1053,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1345,12 +1189,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1554,22 +1392,17 @@ checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1581,7 +1414,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -1672,7 +1504,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.3.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -1744,25 +1576,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1946,27 +1765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,16 +1893,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2321,12 +2109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,17 +2301,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-registry"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "asynchronous"]
 
 [features]
 full = ["openai"]
-openai = []
+openai = ["async-openai", "futures"]
 
 [[test]]
 name = "openai_provider_integration_tests"
@@ -27,9 +27,8 @@ serde = {version = "1.0.219", features = ["derive"]}
 serde_json = { version = "1.0" }
 thiserror = "2.0.12"
 derive_builder = "0.20.2"
-reqwest = { version = "0.12.5", features = ["json"] }
-async-openai = { version = "0.29.0" }
-futures = "0.3"
+futures = { version = "0.3", optional = true }
+async-openai = { version = "0.29.3", optional = true }
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "asynchronous"]
 
 [features]
 full = ["openai"]
-openai = ["async-openai", "futures"]
+openai = ["async-openai"]
 
 [[test]]
 name = "openai_provider_integration_tests"
@@ -27,7 +27,7 @@ serde = {version = "1.0.219", features = ["derive"]}
 serde_json = { version = "1.0" }
 thiserror = "2.0.12"
 derive_builder = "0.20.2"
-futures = { version = "0.3", optional = true }
+futures = "0.3"
 async-openai = { version = "0.29.3", optional = true }
 
 [dev-dependencies]

--- a/src/core/generate_stream.rs
+++ b/src/core/generate_stream.rs
@@ -3,7 +3,7 @@
 use crate::{
     core::{
         language_model::LanguageModel,
-        types::{GenerateStreamResponse, GenerateTextCallOptions, LanguageModelCallOptions},
+        types::{LanguageModelStreamResponse, GenerateTextCallOptions, LanguageModelCallOptions},
         utils::resolve_message,
     },
     error::Result,
@@ -28,7 +28,7 @@ use crate::{
 pub async fn generate_stream(
     mut model: impl LanguageModel,
     options: GenerateTextCallOptions,
-) -> Result<GenerateStreamResponse> {
+) -> Result<LanguageModelStreamResponse> {
     let (system_prompt, messages) =
         resolve_message(options.system, options.prompt, options.messages);
 
@@ -46,5 +46,5 @@ pub async fn generate_stream(
         )
         .await?;
 
-    Ok(GenerateStreamResponse { stream: response })
+    Ok(response)
 }

--- a/src/core/generate_stream.rs
+++ b/src/core/generate_stream.rs
@@ -35,10 +35,11 @@ pub async fn generate_stream(
     let response = model
         .generate_stream(
             LanguageModelCallOptions::builder()
+                .model(options.model)
                 .system(system_prompt)
                 .messages(messages)
                 .max_tokens(options.max_tokens)
-                .temprature(options.temprature)
+                .temperature(options.temperature)
                 .top_p(options.top_p)
                 .top_k(options.top_k)
                 .stop(options.stop)

--- a/src/core/generate_stream.rs
+++ b/src/core/generate_stream.rs
@@ -3,7 +3,7 @@
 use crate::{
     core::{
         language_model::LanguageModel,
-        types::{LanguageModelStreamResponse, GenerateTextCallOptions, LanguageModelCallOptions},
+        types::{GenerateTextCallOptions, LanguageModelCallOptions, LanguageModelStreamResponse},
         utils::resolve_message,
     },
     error::Result,

--- a/src/core/generate_stream.rs
+++ b/src/core/generate_stream.rs
@@ -35,7 +35,6 @@ pub async fn generate_stream(
     let response = model
         .generate_stream(
             LanguageModelCallOptions::builder()
-                .model(options.model)
                 .system(system_prompt)
                 .messages(messages)
                 .max_tokens(options.max_tokens)

--- a/src/core/generate_stream.rs
+++ b/src/core/generate_stream.rs
@@ -4,18 +4,44 @@ use crate::{
     core::{
         language_model::LanguageModel,
         types::{GenerateStreamResponse, GenerateTextCallOptions, LanguageModelCallOptions},
+        utils::resolve_message,
     },
     error::Result,
 };
 
+/// Generates Streaming text using a specified language model.
+///
+/// Generate a text and call tools for a given prompt using a language model.
+/// This function streams the output. If you do not want to stream the output, use `generate_text` instead.
+///
+///
+/// # Arguments
+///
+/// * `model` - A language model that implements the `LanguageModel` trait.
+///
+/// * `options` - A `GenerateTextCallOptions` struct containing the model, prompt,
+///   and other parameters for the request.
+///
+/// # Errors
+///
+/// Returns an `Error` if the underlying model fails to generate a response.
 pub async fn generate_stream(
     mut model: impl LanguageModel,
     options: GenerateTextCallOptions,
 ) -> Result<GenerateStreamResponse> {
+    let (system_prompt, messages) =
+        resolve_message(options.system, options.prompt, options.messages);
+
     let response = model
         .generate_stream(
             LanguageModelCallOptions::builder()
-                .prompt(options.prompt)
+                .system(system_prompt)
+                .messages(messages)
+                .max_tokens(options.max_tokens)
+                .temprature(options.temprature)
+                .top_p(options.top_p)
+                .top_k(options.top_k)
+                .stop(options.stop)
                 .build()?,
         )
         .await?;

--- a/src/core/generate_text.rs
+++ b/src/core/generate_text.rs
@@ -8,16 +8,15 @@ use crate::{
     core::{
         language_model::LanguageModel,
         types::{GenerateTextCallOptions, GenerateTextResponse, LanguageModelCallOptions},
+        utils::resolve_message,
     },
     error::Result,
 };
 
 /// Generates text using a specified language model.
 ///
-/// This function orchestrates the text generation process by taking a configured
-/// set of options, invoking the `generate` method on the provided language model,
-/// and returning a standardized response.
-///
+/// Generate a text and call tools for a given prompt using a language model.
+/// This function does not stream the output. If you want to stream the output, use `generate_stream` instead.
 ///
 /// # Arguments
 ///
@@ -33,10 +32,19 @@ pub async fn generate_text(
     mut model: impl LanguageModel,
     options: GenerateTextCallOptions,
 ) -> Result<GenerateTextResponse> {
+    let (system_prompt, messages) =
+        resolve_message(options.system, options.prompt, options.messages);
+
     let response = model
         .generate(
             LanguageModelCallOptions::builder()
-                .prompt(options.prompt)
+                .system(system_prompt)
+                .messages(messages)
+                .max_tokens(options.max_tokens)
+                .temprature(options.temprature)
+                .top_p(options.top_p)
+                .top_k(options.top_k)
+                .stop(options.stop)
                 .build()?,
         )
         .await?;

--- a/src/core/generate_text.rs
+++ b/src/core/generate_text.rs
@@ -38,7 +38,6 @@ pub async fn generate_text(
     let response = model
         .generate(
             LanguageModelCallOptions::builder()
-                .model(options.model)
                 .system(system_prompt)
                 .messages(messages)
                 .max_tokens(options.max_tokens)

--- a/src/core/generate_text.rs
+++ b/src/core/generate_text.rs
@@ -38,10 +38,11 @@ pub async fn generate_text(
     let response = model
         .generate(
             LanguageModelCallOptions::builder()
+                .model(options.model)
                 .system(system_prompt)
                 .messages(messages)
                 .max_tokens(options.max_tokens)
-                .temprature(options.temprature)
+                .temperature(options.temperature)
                 .top_p(options.top_p)
                 .top_k(options.top_k)
                 .stop(options.stop)

--- a/src/core/language_model.rs
+++ b/src/core/language_model.rs
@@ -6,7 +6,7 @@
 //! unified interface for various operations like text generation or streaming.
 
 use crate::core::types::{
-    LanguageModelCallOptions, LanguageModelResponse, LanguageModelStreamingResponse,
+    LanguageModelStreamResponse, LanguageModelCallOptions, LanguageModelResponse
 };
 use crate::error::Result;
 use async_trait::async_trait;
@@ -47,5 +47,5 @@ pub trait LanguageModel: Send + Sync + std::fmt::Debug {
     async fn generate_stream(
         &mut self,
         options: LanguageModelCallOptions,
-    ) -> Result<LanguageModelStreamingResponse>;
+    ) -> Result<LanguageModelStreamResponse>;
 }

--- a/src/core/language_model.rs
+++ b/src/core/language_model.rs
@@ -6,7 +6,7 @@
 //! unified interface for various operations like text generation or streaming.
 
 use crate::core::types::{
-    LanguageModelStreamResponse, LanguageModelCallOptions, LanguageModelResponse
+    LanguageModelCallOptions, LanguageModelResponse, LanguageModelStreamResponse,
 };
 use crate::error::Result;
 use async_trait::async_trait;

--- a/src/core/language_model.rs
+++ b/src/core/language_model.rs
@@ -20,11 +20,6 @@ use async_trait::async_trait;
 /// generation and streaming responses.
 #[async_trait]
 pub trait LanguageModel: Send + Sync + std::fmt::Debug {
-    /// Returns the identifier of the model (e.g., "gpt-4o", "claude-3-sonnet").
-    ///
-    /// This is used for identifying which model is being used in requests and responses.
-    fn model_name(&self) -> &str;
-
     /// Returns the name of the provider (e.g., "openai", "anthropic").
     ///
     /// This helps differentiate between models with similar names from different services.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -18,4 +18,4 @@ pub use generate_stream::generate_stream;
 pub use generate_text::generate_text;
 pub use language_model::LanguageModel;
 pub use provider::Provider;
-pub use types::{GenerateTextCallOptions, GenerateTextResponse};
+pub use types::{GenerateTextCallOptions, GenerateTextResponse, Role, ModelMessage, SystemModelMessage, UserModelMessage, AssistantModelMessage};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -19,4 +19,7 @@ pub use generate_stream::generate_stream;
 pub use generate_text::generate_text;
 pub use language_model::LanguageModel;
 pub use provider::Provider;
-pub use types::{GenerateTextCallOptions, GenerateTextResponse, Role, ModelMessage, SystemMessage, UserMessage, AssistantMessage};
+pub use types::{
+    AssistantMessage, GenerateTextCallOptions, GenerateTextResponse, ModelMessage, Role,
+    SystemMessage, UserMessage,
+};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,6 +20,6 @@ pub use generate_text::generate_text;
 pub use language_model::LanguageModel;
 pub use provider::Provider;
 pub use types::{
-    AssistantMessage, GenerateTextCallOptions, GenerateTextResponse, ModelMessage, Role,
+    AssistantMessage, GenerateTextCallOptions, GenerateTextResponse, Message, Role,
     SystemMessage, UserMessage,
 };

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,6 +20,6 @@ pub use generate_text::generate_text;
 pub use language_model::LanguageModel;
 pub use provider::Provider;
 pub use types::{
-    AssistantMessage, GenerateTextCallOptions, GenerateTextResponse, Message, Role,
-    SystemMessage, UserMessage,
+    AssistantMessage, GenerateTextCallOptions, GenerateTextResponse, Message, Role, SystemMessage,
+    UserMessage,
 };

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,10 +12,11 @@ pub mod generate_text;
 pub mod language_model;
 pub mod provider;
 pub mod types;
+pub mod utils;
 
 // Re-export key components to provide a clean public API.
 pub use generate_stream::generate_stream;
 pub use generate_text::generate_text;
 pub use language_model::LanguageModel;
 pub use provider::Provider;
-pub use types::{GenerateTextCallOptions, GenerateTextResponse, Role, ModelMessage, SystemModelMessage, UserModelMessage, AssistantModelMessage};
+pub use types::{GenerateTextCallOptions, GenerateTextResponse, Role, ModelMessage, SystemMessage, UserMessage, AssistantMessage};

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -7,6 +7,43 @@ use std::pin::Pin;
 
 use crate::error::{Error, Result};
 
+/// Role for model messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Role {
+    System,
+    User,
+    Assistant,
+}
+
+/// Model message types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ModelMessage {
+    System(SystemModelMessage),
+    User(UserModelMessage),
+    Assistant(AssistantModelMessage),
+}
+
+/// System model message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemModelMessage {
+    pub role: Role,
+    pub content: String,
+}
+
+/// User model message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserModelMessage {
+    pub role: Role,
+    pub content: String,
+}
+
+/// Assistant model message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantModelMessage {
+    pub role: Role,
+    pub content: String,
+}
+
 /// Shortens the definition of the `GenerateTextCallOptions` and
 /// `LanguageModelCallOptions` because all the fields from the first are also
 /// second.
@@ -57,7 +94,7 @@ define_with_lm_call_options!(
     ),
     (
         messages,
-        Option<Vec<String>>,
+        Option<Vec<ModelMessage>>,
         None,
         "The messages to generate text from. uses the chat format. If both prompt and messages are set, prompt will be ignored."
     ),

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -189,7 +189,7 @@ impl LanguageModelCallOptions {
 pub struct LanguageModelStreamResponse {
     /// A stream of responses from the language model.
     pub stream: StreamChunk,
-    
+
     /// The model that generated the response.
     pub model: Option<String>,
 }
@@ -221,8 +221,7 @@ impl LanguageModelResponse {
 
 /// Stream of responses from a language model's streaming API mapped to a common
 /// interface.
-pub type StreamChunk =
-    Pin<Box<dyn Stream<Item = Result<StreamChunkData>> + Send>>;
+pub type StreamChunk = Pin<Box<dyn Stream<Item = Result<StreamChunkData>> + Send>>;
 
 /// Chunked response from a language model.
 pub struct StreamChunkData {
@@ -232,4 +231,3 @@ pub struct StreamChunkData {
     /// The reason the model stopped generating text.
     pub stop_reason: Option<String>,
 }
-

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -18,30 +18,57 @@ pub enum Role {
 /// Model message types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModelMessage {
-    System(SystemModelMessage),
-    User(UserModelMessage),
-    Assistant(AssistantModelMessage),
+    System(SystemMessage),
+    User(UserMessage),
+    Assistant(AssistantMessage),
 }
 
 /// System model message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SystemModelMessage {
-    pub role: Role,
+pub struct SystemMessage {
+    role: Role,
     pub content: String,
+}
+
+impl SystemMessage {
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::System,
+            content: content.into(),
+        }
+    }
 }
 
 /// User model message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserModelMessage {
-    pub role: Role,
+pub struct UserMessage {
+    role: Role,
     pub content: String,
+}
+
+impl UserMessage {
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::User,
+            content: content.into(),
+        }
+    }
 }
 
 /// Assistant model message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssistantModelMessage {
-    pub role: Role,
+pub struct AssistantMessage {
+    role: Role,
     pub content: String,
+}
+
+impl AssistantMessage {
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+        }
+    }
 }
 
 /// Shortens the definition of the `GenerateTextCallOptions` and
@@ -50,7 +77,7 @@ pub struct AssistantModelMessage {
 macro_rules! define_with_lm_call_options {
         ( $( ($field:ident, $typ:ty, $default:expr, $comment:expr) ),* ) => {
             #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
-            #[builder(pattern = "owned", setter(into), build_fn(error = "Error"))]
+            #[builder(pattern = "owned", setter(into), build_fn(name = "build_inner", error = "Error"))]
             pub struct GenerateTextCallOptions  {
                 $(
                     #[doc = $comment]
@@ -58,6 +85,11 @@ macro_rules! define_with_lm_call_options {
                     pub $field: $typ,
                 )*
                 // Define `GenerateTextCallOptions` specific entries here
+
+                /// The prompt to generate text from. Uses the completion format.
+                /// Only one of prompt or messages should be set.
+                #[builder(default = "None")]
+                pub prompt: Option<String>,
 
                 /// Maximum number of retries.
                 #[builder(default = "100")]
@@ -81,22 +113,16 @@ macro_rules! define_with_lm_call_options {
 define_with_lm_call_options!(
     // identifier, type, default, comment
     (
-        prompt,
-        String,
-        "".to_string(),
-        "The prompt to generate text from. uses the completion format. If both prompt and messages are set, prompt will be ignored."
-    ),
-    (
-        system_prompt,
+        system,
         Option<String>,
         None,
-        "The system prompt to generate text from."
+        "System prompt to be used for the request."
     ),
     (
         messages,
         Option<Vec<ModelMessage>>,
         None,
-        "The messages to generate text from. uses the chat format. If both prompt and messages are set, prompt will be ignored."
+        "The messages to generate text from. Uses the chat format. Only one of prompt or messages should be set."
     ),
     (
         max_tokens,
@@ -114,6 +140,26 @@ impl GenerateTextCallOptions {
     /// Creates a new builder for `GenerateTextCallOptions`.
     pub fn builder() -> GenerateTextCallOptionsBuilder {
         GenerateTextCallOptionsBuilder::default()
+    }
+}
+
+impl GenerateTextCallOptionsBuilder {
+    pub fn build(self) -> Result<GenerateTextCallOptions> {
+        let options = self.build_inner()?;
+
+        if options.prompt.is_some() && options.messages.is_some() {
+            return Err(Error::InvalidInput(
+                "Cannot set both prompt and messages".to_string(),
+            ));
+        }
+
+        if options.messages.is_none() && options.prompt.is_none() {
+            return Err(Error::InvalidInput(
+                "Messages or prompt must be set".to_string(),
+            ));
+        }
+
+        Ok(options)
     }
 }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -186,9 +186,12 @@ impl LanguageModelCallOptions {
 }
 
 /// Response from a `generate_stream` call.
-pub struct GenerateStreamResponse {
+pub struct LanguageModelStreamResponse {
     /// A stream of responses from the language model.
-    pub stream: LanguageModelStreamingResponse,
+    pub stream: StreamChunk,
+    
+    /// The model that generated the response.
+    pub model: Option<String>,
 }
 
 // TODO: constract a standard response type
@@ -216,10 +219,17 @@ impl LanguageModelResponse {
     }
 }
 
-/// Chunked response from a language model.
-pub type LanguageModelResponseChunk = LanguageModelResponse; // change this anytime chunk data
-
 /// Stream of responses from a language model's streaming API mapped to a common
 /// interface.
-pub type LanguageModelStreamingResponse =
-    Pin<Box<dyn Stream<Item = Result<LanguageModelResponse>> + Send>>;
+pub type StreamChunk =
+    Pin<Box<dyn Stream<Item = Result<StreamChunkData>> + Send>>;
+
+/// Chunked response from a language model.
+pub struct StreamChunkData {
+    /// The generated text.
+    pub text: String,
+
+    /// The reason the model stopped generating text.
+    pub stop_reason: Option<String>,
+}
+

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -197,6 +197,7 @@ pub struct GenerateStreamResponse {
     pub stream: LanguageModelStreamingResponse,
 }
 
+// TODO: constract a standard response type
 /// Response from a language model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LanguageModelResponse {
@@ -223,4 +224,4 @@ pub type LanguageModelResponseChunk = LanguageModelResponse; // change this anyt
 /// Stream of responses from a language model's streaming API mapped to a common
 /// interface.
 pub type LanguageModelStreamingResponse =
-    Pin<Box<dyn Stream<Item = Result<LanguageModelResponse>>>>;
+    Pin<Box<dyn Stream<Item = Result<LanguageModelResponse>> + Send>>;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -113,6 +113,12 @@ macro_rules! define_with_lm_call_options {
 define_with_lm_call_options!(
     // identifier, type, default, comment
     (
+        model,
+        String,
+        "".to_string(),
+        "The model to use for the request."
+    ),
+    (
         system,
         Option<String>,
         None,
@@ -130,7 +136,7 @@ define_with_lm_call_options!(
         None,
         "The maximum number of tokens to generate."
     ),
-    (temprature, Option<u32>, None, "Randomness."),
+    (temperature, Option<u32>, None, "Randomness."),
     (top_p, Option<u32>, None, "Nucleus sampling."),
     (top_k, Option<u32>, None, "Top-k sampling."),
     (stop, Option<Vec<String>>, None, "Stop sequence.")

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -15,9 +15,9 @@ pub enum Role {
     Assistant,
 }
 
-/// Model message types.
+/// Message Type for model messages.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ModelMessage {
+pub enum Message {
     System(SystemMessage),
     User(UserMessage),
     Assistant(AssistantMessage),
@@ -121,7 +121,7 @@ define_with_lm_call_options!(
     ),
     (
         messages,
-        Option<Vec<ModelMessage>>,
+        Option<Vec<Message>>,
         None,
         "The messages to generate text from. Uses the chat format. Only one of prompt or messages should be set."
     ),

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -114,12 +114,6 @@ macro_rules! define_with_lm_call_options {
 define_with_lm_call_options!(
     // identifier, type, default, comment
     (
-        model,
-        String,
-        "".to_string(),
-        "The model to use for the request."
-    ),
-    (
         system,
         Option<String>,
         None,

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -110,6 +110,7 @@ macro_rules! define_with_lm_call_options {
         };
 }
 
+// TODO: add support for main options
 define_with_lm_call_options!(
     // identifier, type, default, comment
     (

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -200,6 +200,9 @@ pub struct LanguageModelResponse {
 
     /// The model that generated the response.
     pub model: Option<String>,
+
+    /// The reason the model stopped generating text.
+    pub stop_reason: Option<String>,
 }
 
 impl LanguageModelResponse {
@@ -208,6 +211,7 @@ impl LanguageModelResponse {
         Self {
             text: text.into(),
             model: None,
+            stop_reason: None,
         }
     }
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,4 +1,4 @@
-use crate::core::{ModelMessage, SystemMessage, UserMessage};
+use crate::core::{Message, SystemMessage, UserMessage};
 
 /// Resolves the message to be used for text generation.
 ///
@@ -8,14 +8,14 @@ use crate::core::{ModelMessage, SystemMessage, UserMessage};
 pub fn resolve_message(
     system_prompt: Option<String>,
     prompt: Option<String>,
-    messages: Option<Vec<ModelMessage>>,
-) -> (String, Vec<ModelMessage>) {
+    messages: Option<Vec<Message>>,
+) -> (String, Vec<Message>) {
     let messages = messages.unwrap_or_else(|| {
         vec![
-            ModelMessage::System(SystemMessage::new(
+            Message::System(SystemMessage::new(
                 system_prompt.to_owned().unwrap_or_default(),
             )),
-            ModelMessage::User(UserMessage::new(prompt.unwrap_or_default())),
+            Message::User(UserMessage::new(prompt.unwrap_or_default())),
         ]
     });
 
@@ -23,7 +23,7 @@ pub fn resolve_message(
         messages
             .iter()
             .find_map(|m| match m {
-                ModelMessage::System(s) => Some(s.content.to_string()),
+                Message::System(s) => Some(s.content.to_string()),
                 _ => None,
             })
             .unwrap_or_default()

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,0 +1,33 @@
+use crate::core::{ModelMessage, SystemMessage, UserMessage};
+
+/// Resolves the message to be used for text generation.
+///
+/// This function takes a prompt and a list of messages and returns a vector of
+/// messages that can be used for LanguageModelCallOptions.
+/// if no messages are provided, a default message is created with the prompt and system prompt.
+pub fn resolve_message(
+    system_prompt: Option<String>,
+    prompt: Option<String>,
+    messages: Option<Vec<ModelMessage>>,
+) -> (String, Vec<ModelMessage>) {
+    let messages = messages.unwrap_or_else(|| {
+        vec![
+            ModelMessage::System(SystemMessage::new(
+                system_prompt.to_owned().unwrap_or_default(),
+            )),
+            ModelMessage::User(UserMessage::new(prompt.unwrap_or_default())),
+        ]
+    });
+
+    let system = system_prompt.unwrap_or_else(|| {
+        messages
+            .iter()
+            .find_map(|m| match m {
+                ModelMessage::System(s) => Some(s.content.to_string()),
+                _ => None,
+            })
+            .unwrap_or_default()
+    });
+
+    (system, messages)
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,9 +30,6 @@ pub enum Error {
     #[error("API error: {0}")]
     ApiError(String),
 
-    #[error("OpenAI error: {0}")]
-    OpenAIError(#[from] async_openai::error::OpenAIError),
-
     /// An error for invalid input.
     #[error("Invalid input: {0}")]
     InvalidInput(String),
@@ -40,6 +37,11 @@ pub enum Error {
     /// A catch-all for other miscellaneous errors.
     #[error("AI SDK error: {0}")]
     Other(String),
+
+    /// OpenAI provider error.
+    #[cfg(feature = "openai")]
+    #[error("OpenAI error: {0}")]
+    OpenAIError(#[from] async_openai::error::OpenAIError),
 }
 
 /// Implements `From` for `UninitializedFieldError` to convert it to `Error`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,10 @@ pub enum Error {
     #[error("OpenAI error: {0}")]
     OpenAIError(#[from] async_openai::error::OpenAIError),
 
+    /// An error for invalid input.
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
     /// A catch-all for other miscellaneous errors.
     #[error("AI SDK error: {0}")]
     Other(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,10 +30,6 @@ pub enum Error {
     #[error("API error: {0}")]
     ApiError(String),
 
-    /// An error from the underlying `reqwest` client.
-    #[error("HTTP request error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
-
     #[error("OpenAI error: {0}")]
     OpenAIError(#[from] async_openai::error::OpenAIError),
 

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -33,8 +33,7 @@ impl From<LanguageModelCallOptions> for CreateResponse {
             max_output_tokens: options.max_tokens,
             stream: Some(false),
             top_p: options.top_p.map(|t| t as f32 / 100.0),
-            ..Default::default()
-            // TODO: add support for other options
+            ..Default::default() // TODO: add support for other options
         }
     }
 }

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -1,0 +1,76 @@
+//! Helper functions and conversions for the OpenAI provider.
+
+use async_openai::types::{
+    ChatCompletionRequestMessage, ChatCompletionRequestSystemMessage,
+    ChatCompletionRequestUserMessage, ChatCompletionRequestUserMessageContent,
+    ChatCompletionRequestUserMessageContentPart, CreateChatCompletionRequestArgs,
+};
+
+use crate::core::types::LanguageModelCallOptions;
+
+fn user_message(message: &str) -> ChatCompletionRequestMessage {
+    ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage::from(message))
+}
+
+fn system_message(message: &str) -> ChatCompletionRequestMessage {
+    ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage::from(message))
+}
+
+struct OpenAiMessage(ChatCompletionRequestMessage);
+
+impl From<OpenAiMessage> for String {
+    /// Handle the conversion from any `OpenAiMessage` to `String`. Currently it only handles
+    /// user messages that are texts or part of a text. returns empty string if it is not.
+    fn from(value: OpenAiMessage) -> Self {
+        match value.0 {
+            ChatCompletionRequestMessage::User(user_message) => match &user_message.content {
+                ChatCompletionRequestUserMessageContent::Text(text) => text.to_string(),
+                ChatCompletionRequestUserMessageContent::Array(arr) => match arr.first().unwrap() {
+                    ChatCompletionRequestUserMessageContentPart::Text(text) => {
+                        text.text.to_string()
+                    }
+                    _ => "".to_string(),
+                },
+            },
+            _ => "".to_string(),
+        }
+    }
+}
+
+impl From<LanguageModelCallOptions> for CreateChatCompletionRequestArgs {
+    fn from(options: LanguageModelCallOptions) -> Self {
+        let mut request_builder = CreateChatCompletionRequestArgs::default();
+        //request_builder.model(self.model_name().to_string());
+
+        if let Some(max_tokens) = options.max_tokens {
+            request_builder.max_tokens(max_tokens);
+        };
+
+        if let Some(temprature) = options.temprature {
+            request_builder.temperature(temprature as f32 / 100_f32);
+        };
+
+        if let Some(top_p) = options.top_p {
+            request_builder.top_p(top_p as f32 / 100_f32);
+        };
+
+        if options.top_k.is_some() {
+            log::warn!("WrongProviderInput: top_k is not supported by OpenAI");
+        };
+
+        if let Some(stop) = options.stop {
+            request_builder.stop(stop);
+        };
+
+        let msg: ChatCompletionRequestMessage =
+            OpenAiMessage(user_message(&options.prompt)).0;
+        let mut msgs = vec![msg];
+
+        if let Some(system_prompt) = options.system_prompt {
+            msgs.push(system_message(&system_prompt));
+        }
+        request_builder.messages(msgs);
+
+        request_builder
+    }
+}

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -29,7 +29,6 @@ impl From<LanguageModelCallOptions> for CreateResponse {
 
         CreateResponse {
             input: Input::Items(items),
-            model: options.model,
             temperature: options.temperature.map(|t| t as f32 / 100.0),
             max_output_tokens: options.max_tokens,
             stream: Some(false),

--- a/src/providers/openai/conversions.rs
+++ b/src/providers/openai/conversions.rs
@@ -4,7 +4,7 @@ use async_openai::types::responses::{
     CreateResponse, Input, InputContent, InputItem, InputMessage, InputMessageType, Role,
 };
 
-use crate::core::types::{LanguageModelCallOptions, ModelMessage};
+use crate::core::types::{LanguageModelCallOptions, Message};
 
 impl From<LanguageModelCallOptions> for CreateResponse {
     fn from(options: LanguageModelCallOptions) -> Self {
@@ -38,12 +38,12 @@ impl From<LanguageModelCallOptions> for CreateResponse {
     }
 }
 
-impl From<ModelMessage> for InputMessage {
-    fn from(m: ModelMessage) -> Self {
+impl From<Message> for InputMessage {
+    fn from(m: Message) -> Self {
         let (role, text) = match m {
-            ModelMessage::System(s) => (Role::System, s.content),
-            ModelMessage::User(u) => (Role::User, u.content),
-            ModelMessage::Assistant(a) => (Role::Assistant, a.content),
+            Message::System(s) => (Role::System, s.content),
+            Message::User(u) => (Role::User, u.content),
+            Message::Assistant(a) => (Role::Assistant, a.content),
         };
         InputMessage {
             role,

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -51,7 +51,9 @@ impl LanguageModel for OpenAI {
         &mut self,
         options: LanguageModelCallOptions,
     ) -> Result<LanguageModelResponse> {
-        let request: CreateResponse = options.into();
+        let mut request: CreateResponse = options.into();
+        request.model = self.settings.model_name.to_string();
+
         let response: Response = self.client.responses().create(request).await?;
         let text = response
             .output
@@ -76,6 +78,7 @@ impl LanguageModel for OpenAI {
         options: LanguageModelCallOptions,
     ) -> Result<LanguageModelStreamingResponse> {
         let mut request: CreateResponse = options.into();
+        request.model = self.settings.model_name.to_string();
         request.stream = Some(true);
 
         let openai_stream: ResponseStream = self.client.responses().create_stream(request).await?;

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -1,13 +1,9 @@
 //! This module provides the OpenAI provider, which implements the `LanguageModel`
 //! and `Provider` traits for interacting with the OpenAI API.
 
+pub mod conversions;
 pub mod settings;
-
-use async_openai::types::{
-    ChatCompletionRequestMessage, ChatCompletionRequestSystemMessage,
-    ChatCompletionRequestUserMessage, ChatCompletionRequestUserMessageContent,
-    ChatCompletionRequestUserMessageContentPart, CreateChatCompletionRequestArgs,
-};
+use async_openai::types::CreateChatCompletionRequestArgs;
 use async_openai::{Client, config::OpenAIConfig};
 use futures::StreamExt;
 pub use settings::OpenAIProviderSettings;
@@ -38,73 +34,6 @@ impl OpenAI {
             Client::with_config(OpenAIConfig::new().with_api_key(settings.api_key.to_string()));
 
         Self { client, settings }
-    }
-
-    fn user_message(message: &str) -> ChatCompletionRequestMessage {
-        ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage::from(message))
-    }
-
-    fn system_message(message: &str) -> ChatCompletionRequestMessage {
-        ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage::from(message))
-    }
-}
-
-struct OpenAiMessage(ChatCompletionRequestMessage);
-
-impl From<OpenAiMessage> for String {
-    /// Handle the conversion from any `OpenAiMessage` to `String`. Currently it only handles
-    /// user messages that are texts or part of a text. returns empty string if it is not.
-    fn from(value: OpenAiMessage) -> Self {
-        match value.0 {
-            ChatCompletionRequestMessage::User(user_message) => match &user_message.content {
-                ChatCompletionRequestUserMessageContent::Text(text) => text.to_string(),
-                ChatCompletionRequestUserMessageContent::Array(arr) => match arr.first().unwrap() {
-                    ChatCompletionRequestUserMessageContentPart::Text(text) => {
-                        text.text.to_string()
-                    }
-                    _ => "".to_string(),
-                },
-            },
-            _ => "".to_string(),
-        }
-    }
-}
-
-impl From<LanguageModelCallOptions> for CreateChatCompletionRequestArgs {
-    fn from(options: LanguageModelCallOptions) -> Self {
-        let mut request_builder = CreateChatCompletionRequestArgs::default();
-        //request_builder.model(self.model_name().to_string());
-
-        if let Some(max_tokens) = options.max_tokens {
-            request_builder.max_tokens(max_tokens);
-        };
-
-        if let Some(temprature) = options.temprature {
-            request_builder.temperature(temprature as f32 / 100_f32);
-        };
-
-        if let Some(top_p) = options.top_p {
-            request_builder.top_p(top_p as f32 / 100_f32);
-        };
-
-        if options.top_k.is_some() {
-            log::warn!("WrongProviderInput: top_k is not supported by OpenAI");
-        };
-
-        if let Some(stop) = options.stop {
-            request_builder.stop(stop);
-        };
-
-        let msg: ChatCompletionRequestMessage =
-            OpenAiMessage(OpenAI::user_message(&options.prompt)).0;
-        let mut msgs = vec![msg];
-
-        if let Some(system_prompt) = options.system_prompt {
-            msgs.push(OpenAI::system_message(&system_prompt));
-        }
-        request_builder.messages(msgs);
-
-        request_builder
     }
 }
 

--- a/src/providers/openai/settings.rs
+++ b/src/providers/openai/settings.rs
@@ -17,6 +17,10 @@ pub struct OpenAIProviderSettings {
     /// The name of the provider.
     #[builder(default = "\"openai\".to_string()")]
     pub provider_name: String,
+
+    /// The name of the model to use.
+    #[builder(default = "\"gpt-4o\".to_string()")]
+    pub model_name: String,
 }
 
 impl OpenAIProviderSettings {

--- a/src/providers/openai/settings.rs
+++ b/src/providers/openai/settings.rs
@@ -14,10 +14,6 @@ pub struct OpenAIProviderSettings {
     #[builder(default = "std::env::var(\"OPENAI_API_KEY\").unwrap_or_default()")]
     pub api_key: String,
 
-    /// The model to use for text generation.
-    #[builder(default = "\"gpt-4o\".to_string()")]
-    pub model_name: String,
-
     /// The name of the provider.
     #[builder(default = "\"openai\".to_string()")]
     pub provider_name: String,

--- a/tests/openai_provider_integration_tests.rs
+++ b/tests/openai_provider_integration_tests.rs
@@ -1,10 +1,12 @@
 //! Integration tests for the OpenAI provider.
 
 use aisdk::{
+    Error,
     core::{
-        generate_stream, generate_text, AssistantMessage, GenerateTextCallOptions, ModelMessage, SystemMessage, UserMessage
+        AssistantMessage, GenerateTextCallOptions, ModelMessage, SystemMessage, UserMessage,
+        generate_stream, generate_text,
     },
-    providers::openai::{OpenAI, OpenAIProviderSettings}, Error,
+    providers::openai::{OpenAI, OpenAIProviderSettings},
 };
 use dotenv::dotenv;
 use futures::StreamExt;
@@ -74,13 +76,10 @@ async fn test_generate_stream_with_openai() {
     let mut stream = generate_stream(openai, options).await.unwrap().stream;
     let mut buf = String::new();
     while let Some(chunk) = stream.next().await {
-        match chunk {
-            Ok(lang_resp) => {
-                if !lang_resp.text.is_empty() {
-                    buf.push_str(&lang_resp.text);
-                }
-            }
-            _ => {}
+        if let Ok(lang_resp) = chunk
+            && !lang_resp.text.is_empty()
+        {
+            buf.push_str(&lang_resp.text);
         }
     }
     assert!(buf.contains("hello"));
@@ -108,7 +107,7 @@ async fn test_generate_text_with_system_prompt() {
         .system(Some(
             "Only say hello whatever the user says. \n 
             all lowercase no punctuation, prefixes, or suffixes."
-            .to_string(),
+                .to_string(),
         ))
         .prompt(Some("Hello how are you doing?".to_string()))
         .build()
@@ -180,7 +179,7 @@ async fn test_generate_text_with_messages_and_system_prompt() {
         .system(Some(
             "Only say hello whatever the user says. \n
             all lowercase no punctuation, prefixes, or suffixes."
-            .to_string(),
+                .to_string(),
         ))
         .messages(Some(vec![
             ModelMessage::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
@@ -220,7 +219,7 @@ async fn test_generate_text_with_messages_and_inmessage_system_prompt() {
             ModelMessage::System(SystemMessage::new(
                 "Only say hello whatever the user says. \n
                 all lowercase no punctuation, prefixes, or suffixes."
-                .to_string(),
+                    .to_string(),
             )),
             ModelMessage::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
             ModelMessage::Assistant(AssistantMessage::new("How could I help you?".to_string())),

--- a/tests/openai_provider_integration_tests.rs
+++ b/tests/openai_provider_integration_tests.rs
@@ -73,7 +73,9 @@ async fn test_generate_stream_with_openai() {
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
-    let mut stream = generate_stream(openai, options).await.unwrap().stream;
+    let response = generate_stream(openai, options).await.unwrap();
+    let mut stream = response.stream;
+
     let mut buf = String::new();
     while let Some(chunk) = stream.next().await {
         if let Ok(lang_resp) = chunk
@@ -82,6 +84,11 @@ async fn test_generate_stream_with_openai() {
             buf.push_str(&lang_resp.text);
         }
     }
+
+    if let Some(model) = response.model {
+        assert!(model.starts_with("gpt-4o"));
+    }
+
     assert!(buf.contains("hello"));
 }
 

--- a/tests/openai_provider_integration_tests.rs
+++ b/tests/openai_provider_integration_tests.rs
@@ -3,7 +3,7 @@
 use aisdk::{
     Error,
     core::{
-        AssistantMessage, GenerateTextCallOptions, ModelMessage, SystemMessage, UserMessage,
+        AssistantMessage, GenerateTextCallOptions, Message, SystemMessage, UserMessage,
         generate_stream, generate_text,
     },
     providers::openai::{OpenAI, OpenAIProviderSettings},
@@ -140,12 +140,12 @@ async fn test_generate_text_with_messages() {
 
     let options = GenerateTextCallOptions::builder()
         .messages(Some(vec![
-            ModelMessage::System(SystemMessage::new(
+            Message::System(SystemMessage::new(
                 "You are a helpful assistant.".to_string(),
             )),
-            ModelMessage::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
-            ModelMessage::Assistant(AssistantMessage::new("How could I help you?".to_string())),
-            ModelMessage::User(UserMessage::new("Could you tell my name?".to_string())),
+            Message::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
+            Message::Assistant(AssistantMessage::new("How could I help you?".to_string())),
+            Message::User(UserMessage::new("Could you tell my name?".to_string())),
         ]))
         .build()
         .expect("Failed to build GenerateTextCallOptions");
@@ -182,9 +182,9 @@ async fn test_generate_text_with_messages_and_system_prompt() {
                 .to_string(),
         ))
         .messages(Some(vec![
-            ModelMessage::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
-            ModelMessage::Assistant(AssistantMessage::new("How could I help you?".to_string())),
-            ModelMessage::User(UserMessage::new("Could you tell my name?".to_string())),
+            Message::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
+            Message::Assistant(AssistantMessage::new("How could I help you?".to_string())),
+            Message::User(UserMessage::new("Could you tell my name?".to_string())),
         ]))
         .build()
         .expect("Failed to build GenerateTextCallOptions");
@@ -216,14 +216,14 @@ async fn test_generate_text_with_messages_and_inmessage_system_prompt() {
 
     let options = GenerateTextCallOptions::builder()
         .messages(Some(vec![
-            ModelMessage::System(SystemMessage::new(
+            Message::System(SystemMessage::new(
                 "Only say hello whatever the user says. \n
                 all lowercase no punctuation, prefixes, or suffixes."
                     .to_string(),
             )),
-            ModelMessage::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
-            ModelMessage::Assistant(AssistantMessage::new("How could I help you?".to_string())),
-            ModelMessage::User(UserMessage::new("Could you tell my name?".to_string())),
+            Message::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
+            Message::Assistant(AssistantMessage::new("How could I help you?".to_string())),
+            Message::User(UserMessage::new("Could you tell my name?".to_string())),
         ]))
         .build()
         .expect("Failed to build GenerateTextCallOptions");
@@ -246,7 +246,7 @@ async fn test_generate_text_builder_with_both_prompt_and_messages() {
             all lowercase no punctuation, prefixes, or suffixes."
                 .to_string(),
         ))
-        .messages(Some(vec![ModelMessage::User(UserMessage::new(
+        .messages(Some(vec![Message::User(UserMessage::new(
             "Whatsup?, Surafel is here".to_string(),
         ))]))
         .build();


### PR DESCRIPTION
## Description

This PR introduces major improvements to the AISDK core and OpenAI provider, focusing on **message-based generation**, **streaming support**, and **robust integration tests**. Key updates include:

**Core Functionality:**

* Added `ModelMessage` types (`SystemMessage`, `UserMessage`, `AssistantMessage`) and `Role` enum to unify message handling. (7e9627a, fc4d01f)
* Updated `generate_text` and `generate_stream` to support both **prompt** and **chat messages**. (fc4d01f)
* Introduced `resolve_message` utility to handle system prompts and messages consistently.
* Enhanced streaming support to handle **stop events** properly. (6eb30e4)
* Improved input validation for builder options: prevents setting both `prompt` and `messages` simultaneously and requires at least one.

**OpenAI Provider:**

* Migrated `generate_text` and `generate_stream` to the **new OpenAI Responses API**. (a0007a4, fc4d01f)
* Implemented conversions from AISDK types (`LanguageModelCallOptions` and `ModelMessage`) to OpenAI API requests. (afd075c)
* Removed outdated or redundant dependencies and settings (e.g., model name on provider settings, native TLS, `reqwest`). (9441590, 95339b0, 759a3e5)
* Refactored OpenAI module structure for clarity. (4fd76b7)

**Tests:**

* Added comprehensive **integration tests** for:

  * `GenerateTextCallOptions` builder validation. (2fffa97)
  * Generating text with **prompt only**, **system prompt**, **messages**, and combinations of messages + system prompt. (4dd5dc4, 9863ce2)
  * Streaming generation with OpenAI. (9863ce2)


## Related Issue

### None

---

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

---

## Checklist

* [x] I have read the [**[Contributing Guidelines](https://chatgpt.com/CONTRIBUTING.md)**](./CONTRIBUTING.md).
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.
* [x] Any dependent changes have been merged and published in downstream modules.
