### PR TITLE
feat: simplify provider initialization & add type-safe message builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,9 @@ use aisdk::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let settings = OpenAIProviderSettings::builder()
-        .api_key("your-api-key".to_string())
-        .model_name("gpt-4o".to_string())
-        .build()?;
 
-    let openai = OpenAI::new(settings);
+    // with default openai provider settings
+    let openai = OpenAI::new("gpt-5");
 
     let options = GenerateTextCallOptions::builder()
         .prompt("Say hello.")
@@ -71,12 +68,12 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let settings = OpenAIProviderSettings::builder()
-        .api_key("your-api-key".to_string())
-        .model_name("gpt-4o".to_string())
-        .build()?;
 
-    let openai = OpenAI::new(settings);
+    // with custom openai provider settings
+    let openai = OpenAI::builder()
+        .api_key("your-api-key")
+        .model_name("gpt-4o")
+        .build()?;
 
     let options = GenerateTextCallOptions::builder()
         .prompt("Count from 1 to 10.")

--- a/src/core/types/messages.rs
+++ b/src/core/types/messages.rs
@@ -16,8 +16,11 @@ pub enum Message {
     Assistant(AssistantMessage),
 }
 
-//TODO: add Message impl for easy creation of messages + type safety that guarantees system
-//prompts are always first
+impl Message {
+    pub fn builder() -> MessageBuilder<Initial> {
+        MessageBuilder::builder()
+    }
+}
 
 /// System model message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,6 +66,75 @@ impl AssistantMessage {
         Self {
             role: Role::Assistant,
             content: content.into(),
+        }
+    }
+}
+
+/// Message State for type safe message list construction.
+/// Initial state for initial message builder with either system or user message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Initial;
+
+/// Message State for type safe message list construction.
+/// Conversation state is used for only user and assistant message builder.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Conversation;
+
+/// Message Builder with state for type safe message list construction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageBuilder<State = Initial> {
+    messages: Vec<Message>,
+    state: std::marker::PhantomData<State>,
+}
+
+impl MessageBuilder {
+    pub fn builder() -> MessageBuilder<Initial> {
+        MessageBuilder {
+            messages: Vec::new(),
+            state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<State> MessageBuilder<State> {
+    pub fn build(self) -> Vec<Message> {
+        self.messages
+    }
+}
+
+impl MessageBuilder<Initial> {
+    pub fn system(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
+        self.messages
+            .push(Message::System(SystemMessage::new(content)));
+        MessageBuilder {
+            messages: self.messages,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn user(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
+        self.messages.push(Message::User(UserMessage::new(content)));
+        MessageBuilder {
+            messages: self.messages,
+            state: std::marker::PhantomData,
+        }
+    }
+}
+
+impl MessageBuilder<Conversation> {
+    pub fn user(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
+        self.messages.push(Message::User(UserMessage::new(content)));
+        MessageBuilder {
+            messages: self.messages,
+            state: std::marker::PhantomData,
+        }
+    }
+    pub fn assistant(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
+        self.messages
+            .push(Message::Assistant(AssistantMessage::new(content)));
+        MessageBuilder {
+            messages: self.messages,
+            state: std::marker::PhantomData,
         }
     }
 }

--- a/src/core/types/messages.rs
+++ b/src/core/types/messages.rs
@@ -69,7 +69,7 @@ impl Message {
     ///     .build();
     /// ```
     pub fn builder() -> MessageBuilder<Initial> {
-        MessageBuilder::builder()
+        MessageBuilder::default()
     }
 }
 
@@ -145,8 +145,10 @@ impl MessageBuilder {
             state: std::marker::PhantomData,
         }
     }
+}
 
-    pub fn builder() -> MessageBuilder<Initial> {
+impl Default for MessageBuilder {
+    fn default() -> Self {
         MessageBuilder {
             messages: Vec::new(),
             state: std::marker::PhantomData,

--- a/src/core/types/messages.rs
+++ b/src/core/types/messages.rs
@@ -17,21 +17,6 @@ pub enum Message {
 }
 
 impl Message {
-    /// Create a new user message.
-    pub fn user(content: impl Into<String>) -> Self {
-        Self::User(UserMessage::new(content))
-    }
-
-    /// Create a new assistant message.
-    pub fn assistant(content: impl Into<String>) -> Self {
-        Self::Assistant(AssistantMessage::new(content))
-    }
-
-    /// Create a new system message.
-    pub fn system(content: impl Into<String>) -> Self {
-        Self::System(SystemMessage::new(content))
-    }
-
     /// Start a new conversation with an empty message list.
     ///
     /// Returns a `MessageBuilder<Conversation>`, allowing any number of
@@ -89,6 +74,18 @@ impl SystemMessage {
     }
 }
 
+impl From<String> for SystemMessage {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&str> for SystemMessage {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
 /// User model message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserMessage {
@@ -105,6 +102,17 @@ impl UserMessage {
     }
 }
 
+impl From<String> for UserMessage {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&str> for UserMessage {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
 /// Assistant model message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantMessage {
@@ -118,6 +126,12 @@ impl AssistantMessage {
             role: Role::Assistant,
             content: content.into(),
         }
+    }
+}
+
+impl From<String> for AssistantMessage {
+    fn from(value: String) -> Self {
+        Self::new(value)
     }
 }
 
@@ -164,8 +178,7 @@ impl<State> MessageBuilder<State> {
 
 impl MessageBuilder<Initial> {
     pub fn system(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
-        self.messages
-            .push(Message::System(SystemMessage::new(content)));
+        self.messages.push(Message::System(content.into().into()));
         MessageBuilder {
             messages: self.messages,
             state: std::marker::PhantomData,
@@ -173,7 +186,7 @@ impl MessageBuilder<Initial> {
     }
 
     pub fn user(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
-        self.messages.push(Message::User(UserMessage::new(content)));
+        self.messages.push(Message::User(content.into().into()));
         MessageBuilder {
             messages: self.messages,
             state: std::marker::PhantomData,
@@ -183,7 +196,7 @@ impl MessageBuilder<Initial> {
 
 impl MessageBuilder<Conversation> {
     pub fn user(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
-        self.messages.push(Message::User(UserMessage::new(content)));
+        self.messages.push(Message::User(content.into().into()));
         MessageBuilder {
             messages: self.messages,
             state: std::marker::PhantomData,
@@ -191,7 +204,7 @@ impl MessageBuilder<Conversation> {
     }
     pub fn assistant(mut self, content: impl Into<String>) -> MessageBuilder<Conversation> {
         self.messages
-            .push(Message::Assistant(AssistantMessage::new(content)));
+            .push(Message::Assistant(content.into().into()));
         MessageBuilder {
             messages: self.messages,
             state: std::marker::PhantomData,

--- a/src/core/types/messages.rs
+++ b/src/core/types/messages.rs
@@ -17,10 +17,57 @@ pub enum Message {
 }
 
 impl Message {
+    /// Create a new user message.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self::User(UserMessage::new(content))
+    }
+
+    /// Create a new assistant message.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self::Assistant(AssistantMessage::new(content))
+    }
+
+    /// Create a new system message.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self::System(SystemMessage::new(content))
+    }
+
+    /// Start a new conversation with an empty message list.
+    ///
+    /// Returns a `MessageBuilder<Conversation>`, allowing any number of
+    /// `user`/`assistant` calls without forcing an initial system or user message.
+    ///
+    /// # Example
+    /// ```
+    /// use aisdk::core::Message;
+    ///
+    /// let mut msg = Message::conversation_builder();
+    /// for _ in 0..10 {
+    ///     msg = msg.user("hello");
+    /// }
+    /// let messages = msg.build(); // messages is a Vec<Message>
+    /// ```
     pub fn conversation_builder() -> MessageBuilder<Conversation> {
         MessageBuilder::conversation_builder()
     }
 
+    /// Create a new message builder in the initial state.
+    ///
+    /// Returns a `MessageBuilder<Initial>` that enforces type-safe order:
+    /// the first message **must** be either a system prompt or a user message.
+    /// After that, the builder transitions to `Conversation` state and allows
+    /// free mixing of user/assistant messages but not system prompts.
+    ///
+    /// # Example
+    /// ```
+    /// use aisdk::core::Message;
+    ///
+    /// let msgs = Message::builder()
+    ///     .system("You are helpful.")
+    ///     .user("Hello!")
+    ///     .assistant("Hi there.")
+    ///     .build();
+    /// ```
     pub fn builder() -> MessageBuilder<Initial> {
         MessageBuilder::builder()
     }

--- a/src/core/types/messages.rs
+++ b/src/core/types/messages.rs
@@ -17,6 +17,10 @@ pub enum Message {
 }
 
 impl Message {
+    pub fn conversation_builder() -> MessageBuilder<Conversation> {
+        MessageBuilder::conversation_builder()
+    }
+
     pub fn builder() -> MessageBuilder<Initial> {
         MessageBuilder::builder()
     }
@@ -88,6 +92,13 @@ pub struct MessageBuilder<State = Initial> {
 }
 
 impl MessageBuilder {
+    pub fn conversation_builder() -> MessageBuilder<Conversation> {
+        MessageBuilder {
+            messages: Vec::new(),
+            state: std::marker::PhantomData,
+        }
+    }
+
     pub fn builder() -> MessageBuilder<Initial> {
         MessageBuilder {
             messages: Vec::new(),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,4 +1,4 @@
-use crate::core::{Message, SystemMessage, UserMessage};
+use crate::core::Message;
 
 /// Resolves the message to be used for text generation.
 ///
@@ -12,10 +12,8 @@ pub fn resolve_message(
 ) -> (String, Vec<Message>) {
     let messages = messages.unwrap_or_else(|| {
         vec![
-            Message::System(SystemMessage::new(
-                system_prompt.to_owned().unwrap_or_default(),
-            )),
-            Message::User(UserMessage::new(prompt.unwrap_or_default())),
+            Message::System(system_prompt.to_owned().unwrap_or_default().into()),
+            Message::User(prompt.unwrap_or_default().into()),
         ]
     });
 

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -33,12 +33,10 @@ pub struct OpenAI {
 impl OpenAI {
     /// Creates a new `OpenAI` provider with the given settings.
     pub fn new(model_name: impl Into<String>) -> Self {
-        let openai = OpenAIProviderSettingsBuilder::default()
+        OpenAIProviderSettingsBuilder::default()
             .model_name(model_name.into())
             .build()
-            .expect("Failed to build OpenAIProviderSettings");
-
-        openai
+            .expect("Failed to build OpenAIProviderSettings")
     }
 
     /// OpenAI provider setting builder.

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -8,9 +8,9 @@ use async_openai::types::responses::{
 };
 use async_openai::{Client, config::OpenAIConfig};
 use futures::{StreamExt, stream::once};
-pub use settings::OpenAIProviderSettings;
 
 use crate::core::types::LanguageModelStreamResponse;
+use crate::providers::openai::settings::{OpenAIProviderSettings, OpenAIProviderSettingsBuilder};
 use crate::{
     core::{
         language_model::LanguageModel,
@@ -32,11 +32,18 @@ pub struct OpenAI {
 
 impl OpenAI {
     /// Creates a new `OpenAI` provider with the given settings.
-    pub fn new(settings: OpenAIProviderSettings) -> Self {
-        let client =
-            Client::with_config(OpenAIConfig::new().with_api_key(settings.api_key.to_string()));
+    pub fn new(model_name: impl Into<String>) -> Self {
+        let openai = OpenAIProviderSettingsBuilder::default()
+            .model_name(model_name.into())
+            .build()
+            .expect("Failed to build OpenAIProviderSettings");
 
-        Self { client, settings }
+        openai.into()
+    }
+
+    /// OpenAI provider setting builder.
+    pub fn builder() -> OpenAIProviderSettingsBuilder {
+        OpenAIProviderSettings::builder()
     }
 }
 

--- a/src/providers/openai/mod.rs
+++ b/src/providers/openai/mod.rs
@@ -38,7 +38,7 @@ impl OpenAI {
             .build()
             .expect("Failed to build OpenAIProviderSettings");
 
-        openai.into()
+        openai
     }
 
     /// OpenAI provider setting builder.

--- a/tests/openai_provider_integration_tests.rs
+++ b/tests/openai_provider_integration_tests.rs
@@ -220,7 +220,9 @@ async fn test_generate_text_builder_with_both_prompt_and_messages() {
             all lowercase no punctuation, prefixes, or suffixes."
                 .to_string(),
         ))
-        .messages(Some(vec![Message::user("Whatsup?, Surafel is here")]))
+        .messages(Some(vec![Message::User(
+            "Whatsup?, Surafel is here".into(),
+        )]))
         .build();
 
     assert!(options.is_err());

--- a/tests/openai_provider_integration_tests.rs
+++ b/tests/openai_provider_integration_tests.rs
@@ -3,7 +3,7 @@
 use aisdk::{
     Error,
     core::{GenerateTextCallOptions, Message, generate_stream, generate_text},
-    providers::openai::{OpenAI, OpenAIProviderSettings},
+    providers::openai::OpenAI,
 };
 use dotenv::dotenv;
 use futures::StreamExt;
@@ -18,14 +18,6 @@ async fn test_generate_text_with_openai() {
         return;
     }
 
-    let settings = OpenAIProviderSettings::builder()
-        .api_key(std::env::var("OPENAI_API_KEY").unwrap())
-        .model_name("gpt-4o".to_string())
-        .build()
-        .expect("Failed to build OpenAIProviderSettings");
-
-    let openai = OpenAI::new(settings);
-
     let options = GenerateTextCallOptions::builder()
         .prompt(Some(
             "Respond with exactly the word 'hello' in all lowercase.\n 
@@ -35,7 +27,7 @@ async fn test_generate_text_with_openai() {
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
-    let result = generate_text(openai, options).await;
+    let result = generate_text(OpenAI::new("gpt-4o"), options).await;
     assert!(result.is_ok());
 
     let text = result.as_ref().expect("Failed to get result").text.trim();
@@ -52,14 +44,6 @@ async fn test_generate_stream_with_openai() {
         return;
     }
 
-    let settings = OpenAIProviderSettings::builder()
-        .api_key(std::env::var("OPENAI_API_KEY").unwrap())
-        .model_name("gpt-4o".to_string())
-        .build()
-        .expect("Failed to build OpenAIProviderSettings");
-
-    let openai = OpenAI::new(settings);
-
     let options = GenerateTextCallOptions::builder()
         .prompt(Some(
             "Respond with exactly the word 'hello' in all lowercase\n 
@@ -70,7 +54,10 @@ async fn test_generate_stream_with_openai() {
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
-    let response = generate_stream(openai, options).await.unwrap();
+    let response = generate_stream(OpenAI::new("gpt-4o"), options)
+        .await
+        .unwrap();
+
     let mut stream = response.stream;
 
     let mut buf = String::new();
@@ -99,13 +86,12 @@ async fn test_generate_text_with_system_prompt() {
         return;
     }
 
-    let settings = OpenAIProviderSettings::builder()
+    // with custom openai provider settings
+    let openai = OpenAI::builder()
         .api_key(std::env::var("OPENAI_API_KEY").unwrap())
-        .model_name("gpt-4o".to_string())
+        .model_name("gpt-4o")
         .build()
         .expect("Failed to build OpenAIProviderSettings");
-
-    let openai = OpenAI::new(settings);
 
     let options = GenerateTextCallOptions::builder()
         .system(Some(
@@ -134,13 +120,12 @@ async fn test_generate_text_with_messages() {
         return;
     }
 
-    let settings = OpenAIProviderSettings::builder()
+    // with custom openai provider settings
+    let openai = OpenAI::builder()
         .api_key(std::env::var("OPENAI_API_KEY").unwrap())
-        .model_name("gpt-4o".to_string())
+        .model_name("gpt-4o")
         .build()
         .expect("Failed to build OpenAIProviderSettings");
-
-    let openai = OpenAI::new(settings);
 
     let messages = Message::builder()
         .system("You are a helpful assistant.")
@@ -171,14 +156,6 @@ async fn test_generate_text_with_messages_and_system_prompt() {
         return;
     }
 
-    let settings = OpenAIProviderSettings::builder()
-        .api_key(std::env::var("OPENAI_API_KEY").unwrap())
-        .model_name("gpt-4o".to_string())
-        .build()
-        .expect("Failed to build OpenAIProviderSettings");
-
-    let openai = OpenAI::new(settings);
-
     let messages = Message::builder()
         .system("Only say hello whatever the user says. \n all lowercase no punctuation, prefixes, or suffixes.")
         .user("Whatsup?, Surafel is here")
@@ -196,7 +173,7 @@ async fn test_generate_text_with_messages_and_system_prompt() {
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
-    let result = generate_text(openai, options).await;
+    let result = generate_text(OpenAI::new("gpt-4o"), options).await;
     assert!(result.is_ok());
 
     let text = result.as_ref().expect("Failed to get result").text.trim();
@@ -213,14 +190,6 @@ async fn test_generate_text_with_messages_and_inmessage_system_prompt() {
         return;
     }
 
-    let settings = OpenAIProviderSettings::builder()
-        .api_key(std::env::var("OPENAI_API_KEY").unwrap())
-        .model_name("gpt-4o".to_string())
-        .build()
-        .expect("Failed to build OpenAIProviderSettings");
-
-    let openai = OpenAI::new(settings);
-
     let messages = Message::builder()
         .system("Only say hello whatever the user says. \n all lowercase no punctuation, prefixes, or suffixes.")
         .user("Whatsup?, Surafel is here")
@@ -233,7 +202,7 @@ async fn test_generate_text_with_messages_and_inmessage_system_prompt() {
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
-    let result = generate_text(openai, options).await;
+    let result = generate_text(OpenAI::new("gpt-4o"), options).await;
     assert!(result.is_ok());
 
     let text = result.as_ref().expect("Failed to get result").text.trim();

--- a/tests/openai_provider_integration_tests.rs
+++ b/tests/openai_provider_integration_tests.rs
@@ -2,10 +2,7 @@
 
 use aisdk::{
     Error,
-    core::{
-        AssistantMessage, GenerateTextCallOptions, Message, SystemMessage, UserMessage,
-        generate_stream, generate_text,
-    },
+    core::{GenerateTextCallOptions, Message, generate_stream, generate_text},
     providers::openai::{OpenAI, OpenAIProviderSettings},
 };
 use dotenv::dotenv;
@@ -145,15 +142,15 @@ async fn test_generate_text_with_messages() {
 
     let openai = OpenAI::new(settings);
 
+    let messages = Message::builder()
+        .system("You are a helpful assistant.")
+        .user("Whatsup?, Surafel is here")
+        .assistant("How could I help you?")
+        .user("Could you tell my name?")
+        .build();
+
     let options = GenerateTextCallOptions::builder()
-        .messages(Some(vec![
-            Message::System(SystemMessage::new(
-                "You are a helpful assistant.".to_string(),
-            )),
-            Message::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
-            Message::Assistant(AssistantMessage::new("How could I help you?".to_string())),
-            Message::User(UserMessage::new("Could you tell my name?".to_string())),
-        ]))
+        .messages(Some(messages))
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
@@ -182,17 +179,20 @@ async fn test_generate_text_with_messages_and_system_prompt() {
 
     let openai = OpenAI::new(settings);
 
+    let messages = Message::builder()
+        .system("Only say hello whatever the user says. \n all lowercase no punctuation, prefixes, or suffixes.")
+        .user("Whatsup?, Surafel is here")
+        .assistant("How could I help you?")
+        .user("Could you tell my name?")
+        .build();
+
     let options = GenerateTextCallOptions::builder()
         .system(Some(
             "Only say hello whatever the user says. \n
             all lowercase no punctuation, prefixes, or suffixes."
                 .to_string(),
         ))
-        .messages(Some(vec![
-            Message::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
-            Message::Assistant(AssistantMessage::new("How could I help you?".to_string())),
-            Message::User(UserMessage::new("Could you tell my name?".to_string())),
-        ]))
+        .messages(Some(messages))
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
@@ -221,17 +221,15 @@ async fn test_generate_text_with_messages_and_inmessage_system_prompt() {
 
     let openai = OpenAI::new(settings);
 
+    let messages = Message::builder()
+        .system("Only say hello whatever the user says. \n all lowercase no punctuation, prefixes, or suffixes.")
+        .user("Whatsup?, Surafel is here")
+        .assistant("How could I help you?")
+        .user("Could you tell my name?")
+        .build();
+
     let options = GenerateTextCallOptions::builder()
-        .messages(Some(vec![
-            Message::System(SystemMessage::new(
-                "Only say hello whatever the user says. \n
-                all lowercase no punctuation, prefixes, or suffixes."
-                    .to_string(),
-            )),
-            Message::User(UserMessage::new("Whatsup?, Surafel is here".to_string())),
-            Message::Assistant(AssistantMessage::new("How could I help you?".to_string())),
-            Message::User(UserMessage::new("Could you tell my name?".to_string())),
-        ]))
+        .messages(Some(messages))
         .build()
         .expect("Failed to build GenerateTextCallOptions");
 
@@ -253,9 +251,7 @@ async fn test_generate_text_builder_with_both_prompt_and_messages() {
             all lowercase no punctuation, prefixes, or suffixes."
                 .to_string(),
         ))
-        .messages(Some(vec![Message::User(UserMessage::new(
-            "Whatsup?, Surafel is here".to_string(),
-        ))]))
+        .messages(Some(vec![Message::user("Whatsup?, Surafel is here")]))
         .build();
 
     assert!(options.is_err());


### PR DESCRIPTION
## Description

This PR introduces major improvements to the **OpenAI provider initialization** and enhances the **message creation API** for better ergonomics and type safety.

Key updates include:

* **OpenAI Provider**

  * Simplified initialization with `OpenAI::new("model_name")` for default settings.
  * Added `OpenAI::builder()` for customizable provider initialization (API key, provider name, model name).
  * Refactored `OpenAIProviderSettings` into a manual builder to remove reliance on `derive_builder` and provide a more flexible API.

* **Messages**

  * Added single message constructors: `Message::user(..)`, `Message::assistant(..)`, and `Message::system(..)`.
  * Introduced a **conversation builder** (`Message::conversation_builder`) to programmatically append messages without requiring a system message first.
  * Added a **type-safe message builder** (`Message::builder`) that enforces correct ordering:

    * First message must be a system or user message.
    * Subsequent messages can only be user or assistant.
    * Prevents system messages from being injected mid-conversation.

* **Tests & Documentation**

  * Updated integration tests to use the new provider initialization and message builder APIs.
  * Updated README examples to reflect simplified provider setup and message construction.

## Related Issue

### None

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Checklist

* [x] I have read the [**[Contributing Guidelines](https://chatgpt.com/CONTRIBUTING.md)**](./CONTRIBUTING.md).
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.
* [x] Any dependent changes have been merged and published in downstream modules.
